### PR TITLE
Remove model.name

### DIFF
--- a/src/api/__tests__/router.test.js
+++ b/src/api/__tests__/router.test.js
@@ -1,12 +1,12 @@
 const { createTestDB, bootstrapDB } = require('../../util/db');
-const { createBike, createWheel } = require('../../util/model');
+const { createBike, createWheel, models, storages } = require('../../util/model');
 const { createStorageRouter } = require('../router');
 const express = require('express');
 const request = require('supertest');
 
 describe('Router', () => {
   const db = createTestDB();
-  const { models, storages } = bootstrapDB(db);
+  bootstrapDB(db);
   const bikeStorage = new storages.BikeStorage(db);
   const wheelStorage = new storages.WheelStorage(db);
   const router = createStorageRouter(models.Bike, bikeStorage);

--- a/src/api/__tests__/router.test.js
+++ b/src/api/__tests__/router.test.js
@@ -1,5 +1,10 @@
 const { createTestDB, bootstrapDB } = require('../../util/db');
-const { createBike, createWheel, models, storages } = require('../../util/model');
+const {
+  createBike,
+  createWheel,
+  models,
+  storages,
+} = require('../../util/model');
 const { createStorageRouter } = require('../router');
 const express = require('express');
 const request = require('supertest');

--- a/src/model/__tests__/schema.test.js
+++ b/src/model/__tests__/schema.test.js
@@ -6,29 +6,32 @@ const { createStorage } = require('../../storage');
 describe('Schema generation', () => {
   const Price = createModel(
     [Field.value('amount', float()), Field.value('currency')],
-    'price'
   );
+
+  const PriceStorage = createStorage(Price, 'price');
 
   const Wheel = createModel(
     [Field.value('size', float()), Field.value('thickness', float())],
-    'wheel'
   );
+
+  const WheelStorage = createStorage(Wheel, 'wheel');
 
   const Bike = createModel(
     [
       Field.value('brand'),
       Field.value('wheelSize', int(10)),
       Field.value('deliveryDate', date()),
-      Field.model('price', Price),
-      Field.list('wheels', Wheel),
+      Field.model('price', Price, PriceStorage),
+      Field.list('wheels', Wheel, WheelStorage),
     ],
-    'bike'
   );
 
+  const BikeStorage = createStorage(Bike, 'bike');
+
   [
-    createStorage(Price, 'price'),
-    createStorage(Wheel, 'wheel'),
-    createStorage(Bike, 'bike'),
+    PriceStorage,
+    WheelStorage,
+    BikeStorage,
   ].forEach(StorageAdapter => {
     describe(StorageAdapter.getName(), () => {
       it('generates expected schema', () => {

--- a/src/model/__tests__/schema.test.js
+++ b/src/model/__tests__/schema.test.js
@@ -1,6 +1,7 @@
 const { createModel, Field } = require('..');
 const { float, date, int } = require('../transform');
 const { createSchema } = require('../schema');
+const { createStorage } = require('../../storage');
 
 describe('Schema generation', () => {
   const Price = createModel(
@@ -24,10 +25,14 @@ describe('Schema generation', () => {
     'bike'
   );
 
-  [Price, Wheel, Bike].forEach(Model => {
-    describe(Model.name, () => {
+  [
+    createStorage(Price, 'price'),
+    createStorage(Wheel, 'wheel'),
+    createStorage(Bike, 'bike'),
+  ].forEach(StorageAdapter => {
+    describe(StorageAdapter.getName(), () => {
       it('generates expected schema', () => {
-        const statements = createSchema(Model);
+        const statements = createSchema(StorageAdapter);
         statements.forEach(statement => {
           expect(statement).toMatchSnapshot();
         });

--- a/src/model/__tests__/schema.test.js
+++ b/src/model/__tests__/schema.test.js
@@ -2,33 +2,10 @@ const { createModel, Field } = require('..');
 const { float, date, int } = require('../transform');
 const { createSchema } = require('../schema');
 const { createStorage } = require('../../storage');
+const { storages } = require('../../util/model');
 
 describe('Schema generation', () => {
-  const Price = createModel([
-    Field.value('amount', float()),
-    Field.value('currency'),
-  ]);
-
-  const PriceStorage = createStorage(Price, 'price');
-
-  const Wheel = createModel([
-    Field.value('size', float()),
-    Field.value('thickness', float()),
-  ]);
-
-  const WheelStorage = createStorage(Wheel, 'wheel');
-
-  const Bike = createModel([
-    Field.value('brand'),
-    Field.value('wheelSize', int(10)),
-    Field.value('deliveryDate', date()),
-    Field.model('price', Price, PriceStorage),
-    Field.list('wheels', Wheel, WheelStorage),
-  ]);
-
-  const BikeStorage = createStorage(Bike, 'bike');
-
-  [PriceStorage, WheelStorage, BikeStorage].forEach(StorageAdapter => {
+  Object.values(storages).forEach(StorageAdapter => {
     describe(StorageAdapter.getName(), () => {
       it('generates expected schema', () => {
         const statements = createSchema(StorageAdapter);

--- a/src/model/__tests__/schema.test.js
+++ b/src/model/__tests__/schema.test.js
@@ -4,35 +4,31 @@ const { createSchema } = require('../schema');
 const { createStorage } = require('../../storage');
 
 describe('Schema generation', () => {
-  const Price = createModel(
-    [Field.value('amount', float()), Field.value('currency')],
-  );
+  const Price = createModel([
+    Field.value('amount', float()),
+    Field.value('currency'),
+  ]);
 
   const PriceStorage = createStorage(Price, 'price');
 
-  const Wheel = createModel(
-    [Field.value('size', float()), Field.value('thickness', float())],
-  );
+  const Wheel = createModel([
+    Field.value('size', float()),
+    Field.value('thickness', float()),
+  ]);
 
   const WheelStorage = createStorage(Wheel, 'wheel');
 
-  const Bike = createModel(
-    [
-      Field.value('brand'),
-      Field.value('wheelSize', int(10)),
-      Field.value('deliveryDate', date()),
-      Field.model('price', Price, PriceStorage),
-      Field.list('wheels', Wheel, WheelStorage),
-    ],
-  );
+  const Bike = createModel([
+    Field.value('brand'),
+    Field.value('wheelSize', int(10)),
+    Field.value('deliveryDate', date()),
+    Field.model('price', Price, PriceStorage),
+    Field.list('wheels', Wheel, WheelStorage),
+  ]);
 
   const BikeStorage = createStorage(Bike, 'bike');
 
-  [
-    PriceStorage,
-    WheelStorage,
-    BikeStorage,
-  ].forEach(StorageAdapter => {
+  [PriceStorage, WheelStorage, BikeStorage].forEach(StorageAdapter => {
     describe(StorageAdapter.getName(), () => {
       it('generates expected schema', () => {
         const statements = createSchema(StorageAdapter);

--- a/src/model/__tests__/schema.test.js
+++ b/src/model/__tests__/schema.test.js
@@ -1,7 +1,4 @@
-const { createModel, Field } = require('..');
-const { float, date, int } = require('../transform');
 const { createSchema } = require('../schema');
-const { createStorage } = require('../../storage');
 const { storages } = require('../../util/model');
 
 describe('Schema generation', () => {

--- a/src/model/field.js
+++ b/src/model/field.js
@@ -11,6 +11,7 @@ const Type = {
   VALUE: Symbol('value field'),
   LIST: Symbol('list field'),
   MODEL: Symbol('model field'),
+  REFERENCE: Symbol('reference field'),
 };
 
 function value(name, transform = noop) {
@@ -59,9 +60,22 @@ function model(name, Model, StorageAdapter) {
   };
 }
 
+function reference(name, Model) {
+  return {
+    type: Type.REFERENCE,
+    name,
+
+    encode: noop,
+    decode: noop,
+
+    Model,
+  };
+}
+
 module.exports = {
   Type,
   value,
   list,
   model,
+  reference,
 };

--- a/src/model/field.js
+++ b/src/model/field.js
@@ -11,7 +11,6 @@ const Type = {
   VALUE: Symbol('value field'),
   LIST: Symbol('list field'),
   MODEL: Symbol('model field'),
-  REFERENCE: Symbol('reference field'),
 };
 
 function value(name, transform = noop) {
@@ -60,22 +59,9 @@ function model(name, Model, StorageAdapter) {
   };
 }
 
-function reference(name, Model) {
-  return {
-    type: Type.REFERENCE,
-    name,
-
-    encode: noop,
-    decode: noop,
-
-    Model,
-  };
-}
-
 module.exports = {
   Type,
   value,
   list,
   model,
-  reference,
 };

--- a/src/model/model.js
+++ b/src/model/model.js
@@ -20,14 +20,13 @@ function createDeserializer(fields) {
   };
 }
 
-function createModel(fieldSpec, name) {
+function createModel(fieldSpec) {
   const fields = [value('id'), ...fieldSpec];
 
   const encode = createSerializer(fields);
   const decode = createDeserializer(fields);
 
   return {
-    name,
     fields,
     encode,
     decode,

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -35,12 +35,10 @@ function createValueColumn(field) {
 }
 
 function createReferenceColumn(field) {
-  ensureNamed(field.Model);
-
   const parts = [
     field.columnName,
     'uuid',
-    `REFERENCES ${field.Model.name} (id)`,
+    `REFERENCES ${field.StorageAdapter.getName()} (id)`,
   ];
 
   return parts.join(' ');
@@ -58,7 +56,7 @@ function createSchema(StorageAdapter) {
 
   const listFields = Model.fields.filter(field => field.type === Type.LIST);
 
-  const mainTable = Model.name;
+  const mainTable = StorageAdapter.getName();
   const revisionTable = `${mainTable}_revision`;
 
   statements.push(
@@ -93,11 +91,10 @@ function createSchema(StorageAdapter) {
   );
 
   for (const listField of listFields) {
-    ensureNamed(listField.Model);
     const relationTable = listField.name;
     const listTable = `${mainTable}_${relationTable}`;
-    const parent = Model.name;
-    const child = listField.Model.name;
+    const parent = StorageAdapter.getName();
+    const child = listField.StorageAdapter.getName();
     statements.push(
       [
         `CREATE TABLE ${listTable} (`,

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -46,10 +46,10 @@ function createReferenceColumn(field) {
   return parts.join(' ');
 }
 
-function createSchema(Model) {
-  ensureNamed(Model);
-
+function createSchema(StorageAdapter) {
   const statements = [];
+
+  const Model = StorageAdapter.getModel();
 
   const valueFields = Model.fields.filter(field => field.type === Type.VALUE);
   valueFields.shift(); // Bump off Id.

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -1,8 +1,8 @@
 const { Type } = require('./field');
 
-function ensureNamed(Model) {
-  if (!Model.name) {
-    throw new Error(`Model not named`);
+function ensureStorageAdapter(field) {
+  if (!field.StorageAdapter) {
+    throw new Error(`Field missing StorageAdapter`);
   }
 }
 
@@ -35,6 +35,8 @@ function createValueColumn(field) {
 }
 
 function createReferenceColumn(field) {
+  ensureStorageAdapter(field);
+
   const parts = [
     field.columnName,
     'uuid',
@@ -91,6 +93,7 @@ function createSchema(StorageAdapter) {
   );
 
   for (const listField of listFields) {
+    ensureStorageAdapter(listField);
     const relationTable = listField.name;
     const listTable = `${mainTable}_${relationTable}`;
     const parent = StorageAdapter.getName();

--- a/src/storage/__tests__/storage.test.js
+++ b/src/storage/__tests__/storage.test.js
@@ -1,9 +1,9 @@
 const { createTestDB, bootstrapDB } = require('../../util/db');
-const { createBike } = require('../../util/model');
+const { createBike, storages } = require('../../util/model');
 
 describe('Storage', () => {
   const db = createTestDB();
-  const { storages } = bootstrapDB(db);
+  bootstrapDB(db);
 
   describe('Storage', () => {
     let bikeFixture = createBike();

--- a/src/storage/adapter.js
+++ b/src/storage/adapter.js
@@ -1,5 +1,5 @@
 const { createRevisionedStorageAdapter } = require('./adapter/revisioned');
 
 module.exports = {
-  createRevisionedStorageAdapter,
+  createStorage: createRevisionedStorageAdapter,
 };

--- a/src/storage/adapter/relation.js
+++ b/src/storage/adapter/relation.js
@@ -1,28 +1,27 @@
 const { Storage } = require('../storage');
 
-function createRelationStorageAdapter(Model, field) {
-  const tableName = `${Model.name}_${field.name}`;
-  const parent = Model.name;
-  const child = field.Model.name;
+function createRelationStorageAdapter(Model, field, parentName) {
+  const childName = field.StorageAdapter.getName();
+  const tableName = `${parentName}_${field.name}`;
 
   const Query = {
     fetch(parentId) {
       return {
-        text: `SELECT ${child}_id AS id FROM ${tableName} WHERE ${parent}_id = $1`,
+        text: `SELECT ${childName}_id AS id FROM ${tableName} WHERE ${parentName}_id = $1`,
         values: [parentId],
       };
     },
 
     add(parentId, childId) {
       return {
-        text: `INSERT INTO ${tableName} (${parent}_id, ${child}_id) VALUES($1, $2)`,
+        text: `INSERT INTO ${tableName} (${parentName}_id, ${childName}_id) VALUES($1, $2)`,
         values: [parentId, childId],
       };
     },
 
     remove(parentId, childId) {
       return {
-        text: `DELETE FROM ${tableName} WHERE ${parent}_id = $1 AND ${child}_id = $2`,
+        text: `DELETE FROM ${tableName} WHERE ${parentName}_id = $1 AND ${childName}_id = $2`,
         values: [parentId, childId],
       };
     },

--- a/src/storage/adapter/relation.js
+++ b/src/storage/adapter/relation.js
@@ -1,6 +1,6 @@
 const { Storage } = require('../storage');
 
-function createRelationStorageAdapter(ChildStorageAdapter, Model, field) {
+function createRelationStorageAdapter(Model, field) {
   const tableName = `${Model.name}_${field.name}`;
   const parent = Model.name;
   const child = field.Model.name;
@@ -31,7 +31,7 @@ function createRelationStorageAdapter(ChildStorageAdapter, Model, field) {
   class RelationStorageAdapter extends Storage {
     constructor(db) {
       super(db);
-      this.storage = new ChildStorageAdapter(db);
+      this.storage = new field.StorageAdapter(db);
     }
 
     async fetch(parentId) {

--- a/src/storage/adapter/revisioned.js
+++ b/src/storage/adapter/revisioned.js
@@ -11,8 +11,8 @@ function noop(value) {
   return value;
 }
 
-function createRevisionedStorageAdapter(Model) {
-  const tableName = Model.name;
+function createRevisionedStorageAdapter(Model, name) {
+  const tableName = name;
   const valueFields = Model.fields.filter(field => field.type === Type.VALUE);
   const listFields = Model.fields.filter(field => field.type === Type.LIST);
   const modelFields = Model.fields.filter(field => field.type === Type.MODEL);
@@ -44,6 +44,14 @@ function createRevisionedStorageAdapter(Model) {
   };
 
   class RevisionedStorageAdapter extends Storage {
+    static getName() {
+      return name;
+    }
+
+    static getModel() {
+      return Model;
+    }
+
     constructor(db) {
       super(db);
       this.composed = createComposedStorage(db);

--- a/src/storage/adapter/revisioned.js
+++ b/src/storage/adapter/revisioned.js
@@ -29,7 +29,6 @@ function createRevisionedStorageAdapter(Model) {
     const relations = Object.create(null);
     for (const field of listFields) {
       const RelationsStorageAdapter = createRelationStorageAdapter(
-        field.StorageAdapter,
         Model,
         field
       );

--- a/src/storage/adapter/revisioned.js
+++ b/src/storage/adapter/revisioned.js
@@ -30,7 +30,8 @@ function createRevisionedStorageAdapter(Model, name) {
     for (const field of listFields) {
       const RelationsStorageAdapter = createRelationStorageAdapter(
         Model,
-        field
+        field,
+        name,
       );
       relations[field.name] = new RelationsStorageAdapter(db);
     }

--- a/src/storage/adapter/revisioned.js
+++ b/src/storage/adapter/revisioned.js
@@ -31,7 +31,7 @@ function createRevisionedStorageAdapter(Model, name) {
       const RelationsStorageAdapter = createRelationStorageAdapter(
         Model,
         field,
-        name,
+        name
       );
       relations[field.name] = new RelationsStorageAdapter(db);
     }

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -1,5 +1,5 @@
-const { createRevisionedStorageAdapter } = require('./adapter');
+const { createStorage } = require('./adapter');
 
 module.exports = {
-  createRevisionedStorageAdapter,
+  createStorage,
 };

--- a/src/util/db.js
+++ b/src/util/db.js
@@ -1,10 +1,7 @@
 const uuidv4 = require('uuid/v4');
 const { Client } = require('pg');
-const { createModel, Field } = require('../model');
-const { float, date, int } = require('../model/transform');
 const { createSchema } = require('../model/schema');
-const { createStorage } = require('../storage/adapter');
-const { models, storages } = require('./model');
+const { storages } = require('./model');
 
 function createTestDB() {
   const DB_NAME = uuidv4();

--- a/src/util/db.js
+++ b/src/util/db.js
@@ -40,14 +40,14 @@ function bootstrapDB(db) {
     'price'
   );
 
-  const PriceStorage = createStorage(Price);
+  const PriceStorage = createStorage(Price, 'price');
 
   const Wheel = createModel(
     [Field.value('size', float()), Field.value('thickness', float())],
     'wheel'
   );
 
-  const WheelStorage = createStorage(Wheel);
+  const WheelStorage = createStorage(Wheel, 'wheel');
 
   const Bike = createModel(
     [
@@ -60,7 +60,7 @@ function bootstrapDB(db) {
     'bike'
   );
 
-  const BikeStorage = createStorage(Bike);
+  const BikeStorage = createStorage(Bike, 'bike');
 
   beforeAll(async () => {
     for (const Model of [Price, Wheel, Bike]) {

--- a/src/util/db.js
+++ b/src/util/db.js
@@ -4,6 +4,7 @@ const { createModel, Field } = require('../model');
 const { float, date, int } = require('../model/transform');
 const { createSchema } = require('../model/schema');
 const { createStorage } = require('../storage/adapter');
+const { models, storages } = require('./model');
 
 function createTestDB() {
   const DB_NAME = uuidv4();
@@ -35,29 +36,7 @@ function createTestDB() {
 }
 
 function bootstrapDB(db) {
-  const Price = createModel([
-    Field.value('amount', float()),
-    Field.value('currency'),
-  ]);
-
-  const PriceStorage = createStorage(Price, 'price');
-
-  const Wheel = createModel([
-    Field.value('size', float()),
-    Field.value('thickness', float()),
-  ]);
-
-  const WheelStorage = createStorage(Wheel, 'wheel');
-
-  const Bike = createModel([
-    Field.value('brand'),
-    Field.value('wheelSize', int(10)),
-    Field.value('deliveryDate', date()),
-    Field.model('price', Price, PriceStorage),
-    Field.list('wheels', Wheel, WheelStorage),
-  ]);
-
-  const BikeStorage = createStorage(Bike, 'bike');
+  const { PriceStorage, WheelStorage, BikeStorage } = storages;
 
   beforeAll(async () => {
     for (const StorageAdapter of [PriceStorage, WheelStorage, BikeStorage]) {
@@ -67,19 +46,6 @@ function bootstrapDB(db) {
       }
     }
   });
-
-  return {
-    models: {
-      Bike,
-      Price,
-      Wheel,
-    },
-    storages: {
-      BikeStorage,
-      PriceStorage,
-      WheelStorage,
-    },
-  };
 }
 
 module.exports = {

--- a/src/util/db.js
+++ b/src/util/db.js
@@ -37,14 +37,12 @@ function createTestDB() {
 function bootstrapDB(db) {
   const Price = createModel(
     [Field.value('amount', float()), Field.value('currency')],
-    'price'
   );
 
   const PriceStorage = createStorage(Price, 'price');
 
   const Wheel = createModel(
     [Field.value('size', float()), Field.value('thickness', float())],
-    'wheel'
   );
 
   const WheelStorage = createStorage(Wheel, 'wheel');
@@ -57,7 +55,6 @@ function bootstrapDB(db) {
       Field.model('price', Price, PriceStorage),
       Field.list('wheels', Wheel, WheelStorage),
     ],
-    'bike'
   );
 
   const BikeStorage = createStorage(Bike, 'bike');

--- a/src/util/db.js
+++ b/src/util/db.js
@@ -63,8 +63,8 @@ function bootstrapDB(db) {
   const BikeStorage = createStorage(Bike, 'bike');
 
   beforeAll(async () => {
-    for (const Model of [Price, Wheel, Bike]) {
-      const statements = createSchema(Model);
+    for (const StorageAdapter of [PriceStorage, WheelStorage, BikeStorage]) {
+      const statements = createSchema(StorageAdapter);
       for (const statement of statements) {
         await db.query(statement);
       }

--- a/src/util/db.js
+++ b/src/util/db.js
@@ -35,27 +35,27 @@ function createTestDB() {
 }
 
 function bootstrapDB(db) {
-  const Price = createModel(
-    [Field.value('amount', float()), Field.value('currency')],
-  );
+  const Price = createModel([
+    Field.value('amount', float()),
+    Field.value('currency'),
+  ]);
 
   const PriceStorage = createStorage(Price, 'price');
 
-  const Wheel = createModel(
-    [Field.value('size', float()), Field.value('thickness', float())],
-  );
+  const Wheel = createModel([
+    Field.value('size', float()),
+    Field.value('thickness', float()),
+  ]);
 
   const WheelStorage = createStorage(Wheel, 'wheel');
 
-  const Bike = createModel(
-    [
-      Field.value('brand'),
-      Field.value('wheelSize', int(10)),
-      Field.value('deliveryDate', date()),
-      Field.model('price', Price, PriceStorage),
-      Field.list('wheels', Wheel, WheelStorage),
-    ],
-  );
+  const Bike = createModel([
+    Field.value('brand'),
+    Field.value('wheelSize', int(10)),
+    Field.value('deliveryDate', date()),
+    Field.model('price', Price, PriceStorage),
+    Field.list('wheels', Wheel, WheelStorage),
+  ]);
 
   const BikeStorage = createStorage(Bike, 'bike');
 

--- a/src/util/db.js
+++ b/src/util/db.js
@@ -3,7 +3,7 @@ const { Client } = require('pg');
 const { createModel, Field } = require('../model');
 const { float, date, int } = require('../model/transform');
 const { createSchema } = require('../model/schema');
-const { createRevisionedStorageAdapter } = require('../storage/adapter');
+const { createStorage } = require('../storage/adapter');
 
 function createTestDB() {
   const DB_NAME = uuidv4();
@@ -40,14 +40,14 @@ function bootstrapDB(db) {
     'price'
   );
 
-  const PriceStorage = createRevisionedStorageAdapter(Price);
+  const PriceStorage = createStorage(Price);
 
   const Wheel = createModel(
     [Field.value('size', float()), Field.value('thickness', float())],
     'wheel'
   );
 
-  const WheelStorage = createRevisionedStorageAdapter(Wheel);
+  const WheelStorage = createStorage(Wheel);
 
   const Bike = createModel(
     [
@@ -60,7 +60,7 @@ function bootstrapDB(db) {
     'bike'
   );
 
-  const BikeStorage = createRevisionedStorageAdapter(Bike);
+  const BikeStorage = createStorage(Bike);
 
   beforeAll(async () => {
     for (const Model of [Price, Wheel, Bike]) {

--- a/src/util/model.js
+++ b/src/util/model.js
@@ -1,4 +1,31 @@
 const uuidv4 = require('uuid/v4');
+const { createModel, Field } = require('../model');
+const { float, date, int } = require('../model/transform');
+const { createStorage } = require('../storage/adapter');
+
+const Price = createModel([
+  Field.value('amount', float()),
+  Field.value('currency'),
+]);
+
+const PriceStorage = createStorage(Price, 'price');
+
+const Wheel = createModel([
+  Field.value('size', float()),
+  Field.value('thickness', float()),
+]);
+
+const WheelStorage = createStorage(Wheel, 'wheel');
+
+const Bike = createModel([
+  Field.value('brand'),
+  Field.value('wheelSize', int(10)),
+  Field.value('deliveryDate', date()),
+  Field.model('price', Price, PriceStorage),
+  Field.list('wheels', Wheel, WheelStorage),
+]);
+
+const BikeStorage = createStorage(Bike, 'bike');
 
 function createBike() {
   return {
@@ -31,4 +58,14 @@ module.exports = {
   createBike,
   createPrice,
   createWheel,
+  models: {
+    Bike,
+    Wheel,
+    Price,
+  },
+  storages: {
+    BikeStorage,
+    PriceStorage,
+    WheelStorage,
+  },
 };


### PR DESCRIPTION
This PR moves the model name property from model to storage. The only use case for this special name is mapping it to a table name which makes more sense if that is only applicable on storage.